### PR TITLE
CORS Configuration - Allow Cross-Origin Requests

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -7,6 +7,14 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll",
+        b => b.AllowAnyHeader()
+              .AllowAnyOrigin()
+              .AllowAnyMethod());
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -17,6 +25,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors("AllowAll");
 
 app.UseAuthorization();
 


### PR DESCRIPTION
Feature Description:
**Configuring Cross-Origin Resource Sharing (CORS) in a .NET Core application.** 
It's using the AddCors method to add CORS services to the dependency injection container, and then it defines a CORS policy named "AllowAll" using the AddPolicy method.

The policy "AllowAll" is quite permissive, allowing any header (AllowAnyHeader()), any origin (AllowAnyOrigin()), and any HTTP method (AllowAnyMethod()). This is often used during development or in scenarios where you want to **allow cross-origin requests without strict restrictions.**