### PR TITLE
Configure Serilog and Seq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/HotelManagementAPI.sln

--- a/HotelManagementAPI.csproj
+++ b/HotelManagementAPI.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.13" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/NOTE/S3.11.Configure Serilog and Seq.txt
+++ b/NOTE/S3.11.Configure Serilog and Seq.txt
@@ -1,0 +1,17 @@
+Install a few Serilog packages
+
+Add Serilog Configuration in Program.cs
+Remove default logging in appsettings.json
+Add Serilog configuaration in apsettings.json
+
+download and install seq server https://datalust.co/download
+
+Issues:
+Type wrong in appsettings.json therefore met the exception
+"
+This exception was originally thrown at this call stack:
+    System.Uri.CreateThis(string, bool, System.UriKind, System.UriCreationOptions)
+    System.Uri.Uri(string)
+    Serilog.Sinks.Seq.Http.SeqIngestionApiClient.SeqIngestionApiClient(string, string, System.Net.Http.HttpMessageHandler)
+    Serilog.SeqLoggerConfigurationExtensions.Seq(Serilog.Configuration.LoggerSinkConfiguration, string, Serilog.Events.LogEventLevel, int, System.TimeSpan?, string, string, long?, long?, Serilog.Core.LoggingLevelSwitch, System.Net.Http.HttpMessageHandler, long?, int, Serilog.Formatting.ITextFormatter)
+"

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,5 @@
+using Serilog;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -14,6 +16,9 @@ builder.Services.AddCors(options =>
               .AllowAnyOrigin()
               .AllowAnyMethod());
 });
+
+builder.Host.UseSerilog(
+    (ctx, lc) => lc.WriteTo.Console().ReadFrom.Configuration(ctx.Configuration));
 
 var app = builder.Build();
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,9 +1,26 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "./logs/log-.txt",
+          "rollingInterval": "Day"
+        }
+      },
+      {
+        "Name": "Seq",
+        "Args": { "serverUrl": "http://localhost:5341" }
+        
+      }
+    ]
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
`builder.Host.UseSerilog(
    (ctx, lc) => lc.WriteTo.Console().ReadFrom.Configuration(ctx.Configuration));`

**builder**: This likely refers to an instance of IHostBuilder, which is used to configure and build instances of IHost, the host for an ASP.NET Core application.

**Host**: **UseSerilog** is a method provided by IHostBuilder to configure the logging infrastructure for the host.

**UseSerilog**: This method integrates Serilog as the logging provider for the application.

(ctx, lc) => ...: This is a lambda expression used to configure the Serilog logger. It takes two parameters:

ctx: An instance of HostBuilderContext, providing information about the host builder context.
lc: An instance of LoggerConfiguration, representing the configuration for the Serilog logger.
**lc.WriteTo.Console()**: This configures Serilog to write log events to the console.

lc.ReadFrom.Configuration(ctx.Configuration): This instructs Serilog to read **additional configuration** from the application's configuration. It's common to have logger configuration settings in the **appsettings.json** file, and this line ensures that Serilog picks up those settings.

In summary, this code configures the application to use Serilog for logging, with log events being written to the console. It also reads additional configuration for Serilog from the application's configuration, allowing you to customize the logger's behavior using settings in your appsettings.json file or other configuration sources.